### PR TITLE
fix: hide microsoft edge reveal icon

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,12 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  input::-ms-reveal {
+    display: none;
+  }
+}
+
 @layer components {
   .form-input {
     @apply rounded-lg border-gray-300 w-full focus:border-tunnel-bear focus:ring focus:ring-tunnel-bear focus:ring-opacity-50;


### PR DESCRIPTION
Microsoft Edge adds its own "Reveal Password" icon.
Let's hide it!

<img width="483" alt="2025-02-19_21-56-53" src="https://github.com/user-attachments/assets/7eedcf7c-8174-4574-9f7d-e748ec57855e" />
